### PR TITLE
Clear doodles button bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,16 @@ The USGS seeks to achieve this goal by using the HoloViz/Panel ecosystem, which 
 
 ## Installation
 
-Run the following command to create a *conda* environment named `doodler-dev`:
+Run the following command to create a *conda* environment named `holodoodler`:
 
 ```
 conda env create --file environment_dev.yaml
 ```
+Make sure to activate the conda environment with:
+```
+conda activate holodoodler
+```
+before launching the application with any of the following commands.
 
 ## Development
 

--- a/app.py
+++ b/app.py
@@ -70,7 +70,7 @@ side_bar = [
     pn.pane.HTML('<b>Doodling options</b>'),
     app.doodle_drawer.class_toggle_group,
     app.doodle_drawer.param.line_width,
-    app.doodle_drawer.param.clear_all,
+    app.doodle_drawer.clear_all_doodles_button,
     app.settings,
     pn.widgets.Button.from_param(app.param.compute_segmentation, button_type='primary'),
     pn.widgets.Button.from_param(app.param.clear_segmentation, button_type='warning'),

--- a/doodler/components.py
+++ b/doodler/components.py
@@ -533,7 +533,7 @@ class Application(param.Parameterized):
         super().__init__(**params)
 
     @param.depends('doodle_drawer.clear_all', watch=True)
-    def _init_img_pane(self):
+    def _update_img_pane(self):
         self._img_pane.object = (self.input_image.plot * self.doodle_drawer.plot).opts(responsive='height')
 
     @param.depends('input_image.location', watch=True)
@@ -550,7 +550,7 @@ class Application(param.Parameterized):
 
     @param.depends('clear_segmentation', watch=True, on_init=True)
     def _clear_segmentation(self):
-        self._init_img_pane()
+        self._update_img_pane()
         self._init_segmentation_output()
 
     @param.depends('compute_segmentation', watch=True)

--- a/doodler/components.py
+++ b/doodler/components.py
@@ -175,11 +175,11 @@ class DoodleDrawer(pn.viewable.Viewer):
         # Store the previous label class, this is used in ._accumulate_drawn_lines
         self._prev_label_class = self.label_class
 
-        # Create a custom widget (allows dynamically setting disabled property) for the clear_all parameter.
+        # Create a custom widget (allows dynamically setting loading property) for the clear_all parameter.
         self._clear_all_doodles_button = pn.widgets.Button.from_param(
             parameter=self.param.clear_all,
             name='Clear doodles',
-            button_type='default', loading = False
+            button_type='default', loading=False
         )
 
     @param.depends('label_class', watch=True)

--- a/doodler/components.py
+++ b/doodler/components.py
@@ -183,13 +183,11 @@ class DoodleDrawer(pn.viewable.Viewer):
         """Clear the lines drawn in a session.
         """
         # data is always []
-        print("_update_draw_cb data:", data)
         return hv.Contours(data)
 
     def _drawn_cb(self, data: Optional[List[pd.DataFrame]]):
         """Plot all the lines previously drawn.
         """
-        print("_drawn_cb data:", data)
         return hv.Contours(data, kdims=['x', 'y'], vdims=['line_color', 'line_width'])
 
     def _accumulate_drawn_lines(self, event: Optional[param.parameterized.Event] = None):
@@ -201,7 +199,6 @@ class DoodleDrawer(pn.viewable.Viewer):
         # having to deal with that, .split() is used to obtain a dataframe per line.
         lines = [element.dframe() for element in self._draw_stream.element.split()]
         lines = [df_line for df_line in lines if not df_line.empty]
-        print("_accumulate_drawn_lines before:", self._accumulated_lines)
         if not lines:
             return
         # Add to each dataframe/line its properties and its label class
@@ -214,7 +211,6 @@ class DoodleDrawer(pn.viewable.Viewer):
                     df_line[ppt] = getattr(self, ppt)
             df_line['label_class'] = self._prev_label_class
         self._accumulated_lines.extend(lines)
-        print("_accumulate_drawn_lines:", self._accumulated_lines)
         # Clear the plot from the lines just drawn
         self._draw_pipe.event(data=[])
         # Clear the draw stream
@@ -229,7 +225,6 @@ class DoodleDrawer(pn.viewable.Viewer):
         self.clear()
 
     def clear(self):
-        print("clear called!")
         self._accumulated_lines = []
         self._draw_pipe.event(data=[])
         self._drawn_pipe.event(data=[])

--- a/doodler/components.py
+++ b/doodler/components.py
@@ -175,6 +175,13 @@ class DoodleDrawer(pn.viewable.Viewer):
         # Store the previous label class, this is used in ._accumulate_drawn_lines
         self._prev_label_class = self.label_class
 
+        # Create a custom widget (allows dynamically setting disabled property) for the clear_all parameter.
+        self._clear_all_doodles_button = pn.widgets.Button.from_param(
+            parameter=self.param.clear_all,
+            name='Clear doodles',
+            button_type='default', loading = False
+        )
+
     @param.depends('label_class', watch=True)
     def _update_color(self):
         self.line_color = self.class_color_mapping[self.label_class]
@@ -222,7 +229,8 @@ class DoodleDrawer(pn.viewable.Viewer):
 
     @param.depends('clear_all', watch=True)
     def _update_clear(self):
-        self.clear()
+        with pn.param.set_values(self._clear_all_doodles_button, loading = True):
+            self.clear()
 
     def clear(self):
         self._accumulated_lines = []
@@ -247,6 +255,10 @@ class DoodleDrawer(pn.viewable.Viewer):
     @property
     def colormap(self):
         return list(self.class_color_mapping.values())
+
+    @property
+    def clear_all_doodles_button(self):
+        return self._clear_all_doodles_button
 
     @property
     def plot(self):
@@ -534,7 +546,8 @@ class Application(param.Parameterized):
 
     @param.depends('doodle_drawer.clear_all', watch=True)
     def _update_img_pane(self):
-        self._img_pane.object = (self.input_image.plot * self.doodle_drawer.plot).opts(responsive='height')
+        with pn.param.set_values(self._img_pane, loading=True):
+            self._img_pane.object = (self.input_image.plot * self.doodle_drawer.plot).opts(responsive='height')
 
     @param.depends('input_image.location', watch=True)
     def _reset(self):

--- a/doodler/components.py
+++ b/doodler/components.py
@@ -183,11 +183,13 @@ class DoodleDrawer(pn.viewable.Viewer):
         """Clear the lines drawn in a session.
         """
         # data is always []
+        print("_update_draw_cb data:", data)
         return hv.Contours(data)
 
     def _drawn_cb(self, data: Optional[List[pd.DataFrame]]):
         """Plot all the lines previously drawn.
         """
+        print("_drawn_cb data:", data)
         return hv.Contours(data, kdims=['x', 'y'], vdims=['line_color', 'line_width'])
 
     def _accumulate_drawn_lines(self, event: Optional[param.parameterized.Event] = None):
@@ -199,6 +201,7 @@ class DoodleDrawer(pn.viewable.Viewer):
         # having to deal with that, .split() is used to obtain a dataframe per line.
         lines = [element.dframe() for element in self._draw_stream.element.split()]
         lines = [df_line for df_line in lines if not df_line.empty]
+        print("_accumulate_drawn_lines before:", self._accumulated_lines)
         if not lines:
             return
         # Add to each dataframe/line its properties and its label class
@@ -211,6 +214,7 @@ class DoodleDrawer(pn.viewable.Viewer):
                     df_line[ppt] = getattr(self, ppt)
             df_line['label_class'] = self._prev_label_class
         self._accumulated_lines.extend(lines)
+        print("_accumulate_drawn_lines:", self._accumulated_lines)
         # Clear the plot from the lines just drawn
         self._draw_pipe.event(data=[])
         # Clear the draw stream
@@ -225,6 +229,7 @@ class DoodleDrawer(pn.viewable.Viewer):
         self.clear()
 
     def clear(self):
+        print("clear called!")
         self._accumulated_lines = []
         self._draw_pipe.event(data=[])
         self._drawn_pipe.event(data=[])
@@ -532,6 +537,7 @@ class Application(param.Parameterized):
         self._img_pane = pn.pane.HoloViews(sizing_mode='scale_height')
         super().__init__(**params)
 
+    @param.depends('doodle_drawer.clear_all', watch=True)
     def _init_img_pane(self):
         self._img_pane.object = (self.input_image.plot * self.doodle_drawer.plot).opts(responsive='height')
 

--- a/environment_dev.yaml
+++ b/environment_dev.yaml
@@ -1,9 +1,9 @@
-name: holodoodler-dev37
+name: holodoodler
 channels:
   - conda-forge
   - defaults
 dependencies:
- - python=3.7
+ - python=3.8
  - tifffile
  - CairoSVG
  - matplotlib

--- a/environment_dev.yaml
+++ b/environment_dev.yaml
@@ -22,8 +22,8 @@ dependencies:
  - pytest
  - pytest-cov
  - plotly
+ - pydensecrf
  - gdal
  - pip
  - pip:
-   - git+https://github.com/li-plus/pydensecrf.git@0d53acbcf5123d4c88040fe68fbb9805fc5b2fb9
    - doodler-engine


### PR DESCRIPTION
## Issues
After the results of a segmentation appear, I usually click the `Clear segmentation` button and then the `Clear doodles` button to continue testing my code. The segmentation gets cleared instantly, but my doodles don't disappear when I click the `Clear doodles` button for the first time. I need to click the button again for a second time in order for my doodles to disappear.
![consistent_clear_doodles_bug](https://user-images.githubusercontent.com/71415129/207129308-03468c78-535c-4625-ac0d-508ba8e1b3a6.gif)
As you can see in the GIF above, another encountered issue is that any subsequent doodles instantly disappear whenever I change the doodle class/label. This is similar to [Sharon's issue](https://github.com/Doodleverse/holodoodler/issues/1#issue-1299487043), except my issue happens consistently.

## Fix
If you use the [print statements that I added (removed now) in the `DoodleDrawer` class](https://github.com/venuswku/holodoodler/commit/71a680fb3664888523ff53b66f89818686aa6a12), you can see that the `_draw` and `_drawn` doodle plots are updated correctly. That means something went wrong when the `Application` class was displaying these doodle plots. The `Application` class uses `_img_pane` to display the doodle plots, so I added the line below to update `_img_pane` whenever the `Clear doodles` button is clicked.
```python
## doodler > components.py
# ...
class DoodleDrawer(pn.viewable.Viewer):
    # ...
    clear_all = param.Event(label='Clear doodles', doc='Button to clear all the doodles')
    # ...
    @property
    def plot(self):
        return self._drawn * self._draw
# ...
class Application(param.Parameterized):
    def __init__(self, **params):
        self._img_pane = pn.pane.HoloViews(sizing_mode='scale_height')
        super().__init__(**params)
    
    @param.depends('doodle_drawer.clear_all', watch=True)   # <- line that I added
    def _update_img_pane(self):
        self._img_pane.object = (self.input_image.plot * self.doodle_drawer.plot).opts(responsive='height')
    # ...
    @property
    def plot_pane(self):
        return self._img_pane

## app.py
# ...
doodle_drawer = DoodleDrawer(class_color_mapping=CLASS_COLOR_MAPPING, class_toggle_group_type=ClassToggleGroup)
# ...
app = Application(settings=settings, doodle_drawer=doodle_drawer, info=info, input_image=input_image)
# ...
main = app.plot_pane
# ...
template = pn.template.MaterialTemplate(
    title='Doodler',
    logo='assets/1280px-USGS_logo.png',
    header_background='#000000',
    sidebar=side_bar,
    main=[main],
)
```
The `DoodleDrawer` class's `clear_all` parameter changes whenever the `Clear doodles` button is clicked, so making the `_update_img_pane()` function depend on `DoodleDrawer`'s `clear_all` parameter would reassign `_img_pane` with the recently updated doodle plots.
![fixed_clear_doodles_bug](https://user-images.githubusercontent.com/71415129/207129427-6b1a8af1-5459-4667-a65b-fd5c7219c0f6.gif)
Now the doodles don't disappear when I clear all the doodles and choose a new class/label. @2320sharon, when you have time can you test [my branch](https://github.com/venuswku/holodoodler/tree/clear_doodles_button_bug) and check if the bug still appears for you? Hope the bug doesn't happen randomly anymore.🤞🏻